### PR TITLE
nspr: fix/update to 4.13.1

### DIFF
--- a/packages/addons/addon-depends/nspr/package.mk
+++ b/packages/addons/addon-depends/nspr/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="nspr"
-PKG_VERSION="4.13"
+PKG_VERSION="4.13.1"
 PKG_ARCH="any"
 PKG_LICENSE="Mozilla Public License"
 PKG_SITE="http://www.linuxfromscratch.org/blfs/view/svn/general/nspr.html"


### PR DESCRIPTION
in nss package is used version 4.13.1 but here was 4.13